### PR TITLE
Post-receive hook can handle arbitrary branches.

### DIFF
--- a/resources/deploy.sh
+++ b/resources/deploy.sh
@@ -3,6 +3,9 @@ if [ ! -d 'deploy.git' ]; then
   mkdir deploy.git && cd deploy.git
   git init --bare
   echo '#!/bin/sh' > hooks/post-receive
-  echo 'GIT_WORK_TREE=.. git checkout -f' >> hooks/post-receive
+  echo 'while read oldrev newrev ref' >> hooks/post-receive
+  echo 'do' >> hooks/post-receive
+  echo 'GIT_WORK_TREE=.. git checkout -f -B `basename "$ref"` "$newrev"' >> hooks/post-receive
+  echo 'done' >> hooks/post-receive
   chmod +x hooks/post-receive
 fi


### PR DESCRIPTION
This change allows to deploy arbitrary branches to remote servers.

Suppose you have a 'staging' and 'live' remote configured. In order to
work on a new feature you create a feature branch and when you want to
test it on the staging server you just call:

```
pave deploy staging feature-branch
```

and the corresponding branch will get checked out on the remote server.
