### PR TITLE
added host flag to remote execute and pull

### DIFF
--- a/lib/pave/database.rb
+++ b/lib/pave/database.rb
@@ -63,7 +63,7 @@ module Pave
       directory = Pave::Remote.directory(remote)
       db = remote_db
       say "Remotely creating dump of #{db['name']} at #{server}:#{directory}/db/#{dump_file(:remote)}"
-      sh "ssh #{server} \"cd #{directory}/db; mysqldump -u#{db['user']} -p#{db['pass']} #{db['name']} | gzip > #{dump_file(:remote)}\""
+      sh "ssh #{server} \"cd #{directory}/db; mysqldump -h#{db['host']} -u#{db['user']} -p#{db['pass']} #{db['name']} | gzip > #{dump_file(:remote)}\""
     end
 
     def execute_remote_dump_on_local_db
@@ -76,7 +76,7 @@ module Pave
       directory = Pave::Remote.directory(remote)
       db = remote_db
       say "Remotely executing #{dump_file(:local)} on live #{db['name']}"
-      sh "ssh #{server} \"cd #{directory}/db; gzip -dc #{dump_file(:local)} | mysql -u#{db['user']} -p#{db['pass']} #{db['name']}\""
+      sh "ssh #{server} \"cd #{directory}/db; gzip -dc #{dump_file(:local)} | mysql -h#{db['host']} -u#{db['user']} -p#{db['pass']} #{db['name']}\""
     end
 
     def upload_local_dump_to_remote(remote="live")

--- a/lib/pave/version.rb
+++ b/lib/pave/version.rb
@@ -1,3 +1,3 @@
 module Pave
-  VERSION = "0.16.0"
+  VERSION = "0.16.1"
 end


### PR DESCRIPTION
Not sure why we didn't do this from the very beginning. 

Allows to push and pull from external mysql hosts. 
